### PR TITLE
Fixed target output faces (output edge length)

### DIFF
--- a/src/parametrizer-mesh.cpp
+++ b/src/parametrizer-mesh.cpp
@@ -48,18 +48,12 @@ void Parametrizer::Initialize(int faces) {
         rho[i] = 1;
     }
 #ifdef PERFORMANCE_TEST
-    num_vertices = V.cols() * 10;
-    num_faces = num_vertices;
-    scale = sqrt(surface_area / num_faces);
+    scale = sqrt(surface_area / (V.cols() * 10));
 #else
-    if (faces == -1) {
-        num_vertices = V.cols();
-        num_faces = num_vertices;
-        scale = sqrt(surface_area / num_faces);
+    if (faces <= 0) {
+        scale = sqrt(surface_area / V.cols());
     } else {
-        double face_area = surface_area / faces;
-        num_vertices = faces;
-        scale = std::sqrt(face_area) / 2;
+        scale = std::sqrt(surface_area / faces);
     }
 #endif
     double target_len = std::min(scale / 2, average_edge_length * 2);

--- a/src/parametrizer.hpp
+++ b/src/parametrizer.hpp
@@ -106,10 +106,6 @@ class Parametrizer {
     double max_edge_length;
     VectorXd A;
 
-    // target mesh
-    int num_vertices;
-    int num_faces;
-
     // just for test
     DisajointTree disajoint_tree;
 


### PR DESCRIPTION
The actual number of output faces didn't match up with the specified
number. Now the scale (edge length) calculation should be more correct.

Removed unused target vert/face variables