### PR TITLE
Initial border preservation implementation

### DIFF
--- a/src/adjacent-matrix.cpp
+++ b/src/adjacent-matrix.cpp
@@ -2,6 +2,9 @@
 #include "adjacent-matrix.hpp"
 #include "dedge.hpp"
 #include <fstream>
+
+namespace qflow {
+
 void generate_adjacency_matrix_uniform(
 	const MatrixXi &F, const VectorXi &V2E, const VectorXi &E2E,
 	const VectorXi &nonManifold, AdjacentMatrix& adj) {
@@ -28,3 +31,5 @@ void generate_adjacency_matrix_uniform(
 		} while (edge != start);
 	}
 }
+
+} // namespace qflow

--- a/src/adjacent-matrix.hpp
+++ b/src/adjacent-matrix.hpp
@@ -2,6 +2,9 @@
 #define ADJACENT_MATRIX_H_
 
 #include <vector>
+
+namespace qflow {
+
 struct Link
 {
 	Link(){}
@@ -28,5 +31,7 @@ struct TaggedLink {
 };
 
 typedef std::vector<std::vector<Link> > AdjacentMatrix;
+
+} // namespace qflow
 
 #endif

--- a/src/compare-key.hpp
+++ b/src/compare-key.hpp
@@ -4,6 +4,8 @@
 #include <iostream>
 #include <map>
 
+namespace qflow {
+
 struct Key2i
 {
 	Key2i(int x, int y)
@@ -94,5 +96,7 @@ struct KeySorted3i
 	std::pair<int, std::pair<int, int> > key;
 };
 
+
+} // namespace qflow
 
 #endif

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -22,9 +22,13 @@ const int GRAIN_SIZE = 1024;
 
 #include <chrono>
 
+namespace qflow {
+
 // simulation of Windows GetTickCount()
 unsigned long long inline GetCurrentTime64() {
     using namespace std::chrono;
     return duration_cast<milliseconds>(steady_clock::now().time_since_epoch()).count();
 }
+} // namespace qflow
+
 #endif

--- a/src/dedge.cpp
+++ b/src/dedge.cpp
@@ -8,8 +8,10 @@
 #include <vector>
 #include "compare-key.hpp"
 #ifdef WITH_TBB
-#include "tbb_common.h"
+#include "tbb/tbb.h"
 #endif
+namespace qflow {
+
 inline int dedge_prev(int e, int deg) { return (e % deg == 0u) ? e + (deg - 1) : e - 1; }
 
 inline bool atomicCompareAndExchange(volatile int* v, uint32_t newValue, int oldValue) {
@@ -214,7 +216,7 @@ void compute_direct_graph_quad(std::vector<Vector3d>& V, std::vector<Vector4i>& 
                 for (uint32_t i = 0; i < deg; ++i) {
                     uint32_t idx_cur = F[f][i], idx_next = F[f][(i + 1) % deg],
                              edge_id = deg * f + i;
-                    if (idx_cur >= V.cols() || idx_next >= V.cols())
+                    if (idx_cur >= V.size() || idx_next >= V.size())
                         throw std::runtime_error(
                             "Mesh data contains an out-of-bounds vertex reference!");
                     if (idx_cur == idx_next) continue;
@@ -481,3 +483,5 @@ void remove_nonmanifold(std::vector<Vector4i>& F, std::vector<Vector3d>& V) {
         std::cout << "Faces reduced from " << nFacesOrig << " -> " << nFaces << std::endl;
     }
 }
+
+} // namespace qflow

--- a/src/dedge.hpp
+++ b/src/dedge.hpp
@@ -5,6 +5,8 @@
 #include <Eigen/Dense>
 #include <vector>
 
+namespace qflow {
+
 using namespace Eigen;
 
 inline int dedge_prev_3(int e) { return (e % 3 == 0) ? e + 2 : e - 1; }
@@ -17,5 +19,7 @@ void compute_direct_graph_quad(std::vector<Vector3d>& V, std::vector<Vector4i>& 
                                std::vector<int>& E2E, VectorXi& boundary, VectorXi& nonManifold);
 
 void remove_nonmanifold(std::vector<Vector4i> &F, std::vector<Vector3d> &V);
+
+} // namespace qflow
 
 #endif

--- a/src/disajoint-tree.hpp
+++ b/src/disajoint-tree.hpp
@@ -2,6 +2,9 @@
 #define DISAJOINT_TREE_H_
 
 #include <vector>
+
+namespace qflow {
+
 class DisajointTree {
    public:
     DisajointTree() {}
@@ -142,5 +145,7 @@ class DisajointOrientTree {
     std::vector<int> indices;
     std::vector<int> rank;
 };
+
+} // namespace qflow
 
 #endif

--- a/src/dset.hpp
+++ b/src/dset.hpp
@@ -5,6 +5,8 @@
 #include <atomic>
 #include <iostream>
 
+namespace qflow {
+
 /**
 * Lock-free parallel disjoint set data structure (aka UNION-FIND)
 * with path compression and union by rank
@@ -155,5 +157,7 @@ public:
 
 	mutable std::vector<std::atomic<uint64_t>> mData;
 };
+
+} // namespace qflow
 
 #endif /* __UNIONFIND_H */

--- a/src/field-math.hpp
+++ b/src/field-math.hpp
@@ -8,6 +8,9 @@
 #include <Eigen/Dense>
 #include <algorithm>
 #include <vector>
+
+namespace qflow {
+
 using namespace Eigen;
 
 struct DEdge
@@ -474,5 +477,7 @@ inline Vector3d TravelField(Vector3d p, Vector3d &pt, double &len, int &f, Vecto
 
     return p;
 }
+
+} // namespace qflow
 
 #endif

--- a/src/flow.hpp
+++ b/src/flow.hpp
@@ -20,6 +20,8 @@
 using namespace boost;
 using namespace Eigen;
 
+namespace qflow {
+
 class MaxFlowHelper {
    public:
     MaxFlowHelper() {}
@@ -367,5 +369,7 @@ class ECMaxFlowHelper : public MaxFlowHelper {
     }
     std::vector<std::list<FlowInfo>> graph;
 };
+
+} // namespace qflow
 
 #endif

--- a/src/hierarchy.cpp
+++ b/src/hierarchy.cpp
@@ -23,6 +23,11 @@ Hierarchy::Hierarchy() {
     mToLower.resize(MAX_DEPTH);
     mToUpper.resize(MAX_DEPTH);
     rng_seed = 0;
+
+    mCQ.reserve(MAX_DEPTH + 1);
+    mCQw.reserve(MAX_DEPTH + 1);
+    mCO.reserve(MAX_DEPTH + 1);
+    mCOw.reserve(MAX_DEPTH + 1);
 }
 
 #undef max
@@ -30,6 +35,7 @@ Hierarchy::Hierarchy() {
 void Hierarchy::Initialize(double scale, int with_scale) {
     this->with_scale = with_scale;
     generate_graph_coloring_deterministic(mAdj[0], mV[0].cols(), mPhases[0]);
+
     for (int i = 0; i < MAX_DEPTH; ++i) {
         DownsampleGraph(mAdj[i], mV[i], mN[i], mA[i], mV[i + 1], mN[i + 1], mA[i + 1], mToUpper[i],
                         mToLower[i], mAdj[i + 1]);
@@ -48,6 +54,11 @@ void Hierarchy::Initialize(double scale, int with_scale) {
     mO.resize(mV.size());
     mS.resize(mV.size());
     mK.resize(mV.size());
+
+    mCO.resize(mV.size());
+    mCOw.resize(mV.size());
+    mCQ.resize(mV.size());
+    mCQw.resize(mV.size());
 
     //Set random seed
     srand(rng_seed);
@@ -1090,6 +1101,124 @@ void Hierarchy::PropagateEdge() {
     }
 }
 
+void Hierarchy::clearConstraints() {
+    int levels = mV.size();
+    if (levels == 0) return;
+    for (int i = 0; i < levels; ++i) {
+        int size = mV[i].cols();
+        mCQ[i].resize(3, size);
+        mCO[i].resize(3, size);
+        mCQw[i].resize(size);
+        mCOw[i].resize(size);
+        mCQw[i].setZero();
+        mCOw[i].setZero();
+    }
+}
+
+void Hierarchy::propagateConstraints() {
+    int levels = mV.size();
+    if (levels == 0) return;
+
+    for (int l = 0; l < levels - 1; ++l) {
+        auto& N = mN[l];
+        auto& N_next = mN[l + 1];
+        auto& V = mV[l];
+        auto& V_next = mV[l + 1];
+        auto& CQ = mCQ[l];
+        auto& CQ_next = mCQ[l + 1];
+        auto& CQw = mCQw[l];
+        auto& CQw_next = mCQw[l + 1];
+        auto& CO = mCO[l];
+        auto& CO_next = mCO[l + 1];
+        auto& COw = mCOw[l];
+        auto& COw_next = mCOw[l + 1];
+        auto& toUpper = mToUpper[l];
+        MatrixXd& S = mS[l];
+
+        for (uint32_t i = 0; i != mV[l + 1].cols(); ++i) {
+            Vector2i upper = toUpper.col(i);
+            Vector3d cq = Vector3d::Zero(), co = Vector3d::Zero();
+            float cqw = 0.0f, cow = 0.0f;
+
+            bool has_cq0 = CQw[upper[0]] != 0;
+            bool has_cq1 = upper[1] != -1 && CQw[upper[1]] != 0;
+            bool has_co0 = COw[upper[0]] != 0;
+            bool has_co1 = upper[1] != -1 && COw[upper[1]] != 0;
+
+            if (has_cq0 && !has_cq1) {
+                cq = CQ.col(upper[0]);
+                cqw = CQw[upper[0]];
+            } else if (has_cq1 && !has_cq0) {
+                cq = CQ.col(upper[1]);
+                cqw = CQw[upper[1]];
+            } else if (has_cq1 && has_cq0) {
+                Vector3d q_i = CQ.col(upper[0]);
+                Vector3d n_i = CQ.col(upper[0]);
+                Vector3d q_j = CQ.col(upper[1]);
+                Vector3d n_j = CQ.col(upper[1]);
+                auto result = compat_orientation_extrinsic_4(q_i, n_i, q_j, n_j);
+                cq = result.first * CQw[upper[0]] + result.second * CQw[upper[1]];
+                cqw = (CQw[upper[0]] + CQw[upper[1]]);
+            }
+            if (cq != Vector3d::Zero()) {
+                Vector3d n = N_next.col(i);
+                cq -= n.dot(cq) * n;
+                if (cq.squaredNorm() > RCPOVERFLOW) cq.normalize();
+            }
+
+            if (has_co0 && !has_co1) {
+                co = CO.col(upper[0]);
+                cow = COw[upper[0]];
+            } else if (has_co1 && !has_co0) {
+                co = CO.col(upper[1]);
+                cow = COw[upper[1]];
+            } else if (has_co1 && has_co0) {
+                double scale_x = mScale;
+                double scale_y = mScale;
+                if (with_scale) {
+                  // FIXME
+                    // scale_x *= S(0, i);
+                    // scale_y *= S(1, i);
+                }
+                double inv_scale_x = 1.0f / scale_x;
+                double inv_scale_y = 1.0f / scale_y;
+
+                double scale_x_1 = mScale;
+                double scale_y_1 = mScale;
+                if (with_scale) {
+                  // FIXME
+                    // scale_x_1 *= S(0, j);
+                    // scale_y_1 *= S(1, j);
+                }
+                double inv_scale_x_1 = 1.0f / scale_x_1;
+                double inv_scale_y_1 = 1.0f / scale_y_1;
+                auto result = compat_position_extrinsic_4(
+                    V.col(upper[0]), N.col(upper[0]), CQ.col(upper[0]), CO.col(upper[0]),
+                    V.col(upper[1]), N.col(upper[1]), CQ.col(upper[1]), CO.col(upper[1]), scale_x,
+                    scale_y, inv_scale_x, inv_scale_y, scale_x_1, scale_y_1, inv_scale_x_1,
+                    inv_scale_y_1);
+                cow = COw[upper[0]] + COw[upper[1]];
+                co = (result.first * COw[upper[0]] + result.second * COw[upper[1]]) / cow;
+            }
+            if (co != Vector3d::Zero()) {
+                Vector3d n = N_next.col(i), v = V_next.col(i);
+                co -= n.dot(cq - v) * n;
+            }
+#if 0
+                        cqw *= 0.5f;
+                        cow *= 0.5f;
+#else
+            if (cqw > 0) cqw = 1;
+            if (cow > 0) cow = 1;
+#endif
+
+            CQw_next[i] = cqw;
+            COw_next[i] = cow;
+            CQ_next.col(i) = cq;
+            CO_next.col(i) = co;
+        }
+    }
+}
 #ifdef WITH_CUDA
 #include <cuda_runtime.h>
 

--- a/src/hierarchy.hpp
+++ b/src/hierarchy.hpp
@@ -14,6 +14,8 @@
 
 using namespace Eigen;
 
+namespace qflow {
+
 class Hierarchy {
    public:
     Hierarchy();
@@ -39,6 +41,7 @@ class Hierarchy {
     void LoadFromFile(FILE* fp);
 
     double mScale;
+    int rng_seed;
 
     MatrixXi mF;    // mF(i, j) i \in [0, 3) ith index in face j
     VectorXi mE2E;  // inverse edge
@@ -81,4 +84,7 @@ class Hierarchy {
     void CopyToHost();
 #endif
 };
+
+} // namespace qflow
+
 #endif

--- a/src/hierarchy.hpp
+++ b/src/hierarchy.hpp
@@ -40,6 +40,9 @@ class Hierarchy {
     void SaveToFile(FILE* fp);
     void LoadFromFile(FILE* fp);
 
+    void clearConstraints();
+    void propagateConstraints();
+
     double mScale;
     int rng_seed;
 
@@ -57,6 +60,12 @@ class Hierarchy {
     std::vector<MatrixXi> mToUpper;  // mToUpper[h](i, j) \in V; i \in [0, 2); j \in V
     std::vector<MatrixXd> mS;
     std::vector<MatrixXd> mK;
+
+    // constraints
+    std::vector<MatrixXd> mCQ;
+    std::vector<MatrixXd> mCO;
+    std::vector<VectorXd> mCQw;
+    std::vector<VectorXd> mCOw;
 
     int with_scale;
 

--- a/src/loader.cpp
+++ b/src/loader.cpp
@@ -11,6 +11,8 @@
 #include <fstream>
 #include <unordered_map>
 
+namespace qflow {
+
 inline std::vector<std::string> &str_tokenize(const std::string &s, char delim, std::vector<std::string> &elems, bool include_empty = false) {
 	std::stringstream ss(s);
 	std::string item;
@@ -153,3 +155,5 @@ void load(const char* filename, MatrixXd& V, MatrixXi& F)
 	for (uint32_t i = 0; i<vertices.size(); ++i)
 		V.col(i) = positions.at(vertices[i].p - 1);
 }
+
+} // namespace qflow

--- a/src/loader.hpp
+++ b/src/loader.hpp
@@ -4,8 +4,12 @@
 #include <Eigen/Core>
 #include <vector>
 
+namespace qflow {
+
 using namespace Eigen;
 
 void load(const char* filename, MatrixXd& V, MatrixXi& F);
+
+} // namespace qflow
 
 #endif

--- a/src/localsat.cpp
+++ b/src/localsat.cpp
@@ -14,6 +14,8 @@
 #include <utility>
 #include <vector>
 
+namespace qflow {
+
 const int max_depth = 0;
 
 using namespace Eigen;
@@ -289,3 +291,5 @@ void ExportLocalSat(std::vector<Vector2i> &edge_diff, const std::vector<Vector3i
         edge_diff[i][1] = value[2 * i + 1];
     }
 }
+
+} // namespace qflow

--- a/src/localsat.hpp
+++ b/src/localsat.hpp
@@ -4,6 +4,8 @@
 #include <Eigen/Core>
 #include <vector>
 
+namespace qflow {
+
 using namespace Eigen;
 
 enum class SolverStatus {
@@ -23,5 +25,7 @@ SolverStatus SolveSatProblem(int n_variable, std::vector<int> &value,
 void ExportLocalSat(std::vector<Vector2i> &edge_diff, const std::vector<Vector3i> &face_edgeIds,
                     const std::vector<Vector3i> &face_edgeOrients, const MatrixXi &F,
                     const VectorXi &V2E, const VectorXi &E2E);
+
+} // namespace qflow
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,6 +30,8 @@ int main(int argc, char** argv) {
             output_obj = argv[i + 1];
         } else if (strcmp(argv[i], "-sharp") == 0) {
             field.flag_preserve_sharp = 1;
+        } else if (strcmp(argv[i], "-border") == 0) {
+            field.flag_preserve_border = 1;
         } else if (strcmp(argv[i], "-adaptive") == 0) {
             field.flag_adaptive_scale = 1;
         } else if (strcmp(argv[i], "-mcf") == 0) {
@@ -53,6 +55,29 @@ int main(int argc, char** argv) {
     field.Initialize(faces);
     t2 = GetCurrentTime64();
     printf("Use %lf seconds\n", (t2 - t1) * 1e-3);
+
+    if (field.flag_preserve_border) {
+        printf("Add border constrains...\n");
+        Hierarchy& mRes = field.hierarchy;
+        mRes.clearConstraints();
+        for (uint32_t i = 0; i < 3 * mRes.mF.cols(); ++i) {
+            if (mRes.mE2E[i] == -1) {
+                uint32_t i0 = mRes.mF(i % 3, i / 3);
+                uint32_t i1 = mRes.mF((i + 1) % 3, i / 3);
+                Vector3d p0 = mRes.mV[0].col(i0), p1 = mRes.mV[0].col(i1);
+                Vector3d edge = p1 - p0;
+                if (edge.squaredNorm() > 0) {
+                    edge.normalize();
+                    mRes.mCO[0].col(i0) = p0;
+                    mRes.mCO[0].col(i1) = p1;
+                    mRes.mCQ[0].col(i0) = mRes.mCQ[0].col(i1) = edge;
+                    mRes.mCQw[0][i0] = mRes.mCQw[0][i1] = mRes.mCOw[0][i0] = mRes.mCOw[0][i1] =
+                        1.0;
+                }
+            }
+        }
+        mRes.propagateConstraints();
+    }
 
     printf("Solve Orientation Field...\n");
     t1 = GetCurrentTime64();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,10 +2,13 @@
 #include "field-math.hpp"
 #include "optimizer.hpp"
 #include "parametrizer.hpp"
+#include <stdlib.h>
 
 #ifdef WITH_CUDA
 #include <cuda_runtime.h>
 #endif
+
+using namespace qflow;
 
 Parametrizer field;
 
@@ -33,6 +36,8 @@ int main(int argc, char** argv) {
             field.flag_minimum_cost_flow = 1;
         } else if (strcmp(argv[i], "-sat") == 0) {
             field.flag_aggresive_sat = 1;
+        } else if (strcmp(argv[i], "-seed") == 0) {
+            field.hierarchy.rng_seed = atoi(argv[i + 1]);
         }
     }
     printf("%d %s %s\n", faces, input_obj.c_str(), output_obj.c_str());
@@ -44,7 +49,10 @@ int main(int argc, char** argv) {
     }
 
     printf("Initialize...\n");
+    t1 = GetCurrentTime64();
     field.Initialize(faces);
+    t2 = GetCurrentTime64();
+    printf("Use %lf seconds\n", (t2 - t1) * 1e-3);
 
     printf("Solve Orientation Field...\n");
     t1 = GetCurrentTime64();

--- a/src/merge-vertex.cpp
+++ b/src/merge-vertex.cpp
@@ -5,6 +5,8 @@
 #include <map>
 #include <vector>
 
+namespace qflow {
+
 void merge_close(MatrixXd& V, MatrixXi& F, double threshold)
 {
 	std::map<Key3f, int> vid_maps;
@@ -38,3 +40,5 @@ void merge_close(MatrixXd& V, MatrixXi& F, double threshold)
 	memcpy(newF.data(), F.data(), sizeof(int) * 3 * f_num);
 	F = std::move(newF);
 }
+
+} // namespace qflow

--- a/src/merge-vertex.hpp
+++ b/src/merge-vertex.hpp
@@ -2,8 +2,13 @@
 #define MERGE_VERTEX_H_
 
 #include <Eigen/Core>
+
+namespace qflow {
+
 using namespace Eigen;
 
 void merge_close(MatrixXd& V, MatrixXi& F, double threshold);
+
+} // namespace qflow
 
 #endif

--- a/src/optimizer.cpp
+++ b/src/optimizer.cpp
@@ -42,6 +42,8 @@ void Optimizer::optimize_orientations(Hierarchy& mRes) {
     for (int level = mRes.mN.size() - 1; level >= 0; --level) {
         AdjacentMatrix& adj = mRes.mAdj[level];
         const MatrixXd& N = mRes.mN[level];
+        const MatrixXd& CQ = mRes.mCQ[level];
+        const VectorXd& CQw = mRes.mCQw[level];
         MatrixXd& Q = mRes.mQ[level];
         auto& phases = mRes.mPhases[level];
         for (int iter = 0; iter < levelIterations; ++iter) {
@@ -69,6 +71,20 @@ void Optimizer::optimize_orientations(Hierarchy& mRes) {
                         double norm = sum.norm();
                         if (norm > RCPOVERFLOW) sum /= norm;
                     }
+
+                    if (CQw.size() > 0) {
+                        float cw = CQw[i];
+                        if (cw != 0) {
+                            std::pair<Vector3d, Vector3d> value =
+                                compat_orientation_extrinsic_4(sum, n_i, CQ.col(i), n_i);
+                            sum = value.first * (1 - cw) + value.second * cw;
+                            sum -= n_i * n_i.dot(sum);
+
+                            float norm = sum.norm();
+                            if (norm > RCPOVERFLOW) sum /= norm;
+                        }
+                    }
+
                     if (weight_sum > 0) {
                         Q.col(i) = sum;
                     }
@@ -260,6 +276,9 @@ void Optimizer::optimize_positions(Hierarchy& mRes, int with_scale) {
         for (int iter = 0; iter < levelIterations; ++iter) {
             AdjacentMatrix& adj = mRes.mAdj[level];
             const MatrixXd &N = mRes.mN[level], &Q = mRes.mQ[level], &V = mRes.mV[level];
+            const MatrixXd& CQ = mRes.mCQ[level];
+            const MatrixXd& CO = mRes.mCO[level];
+            const VectorXd& COw = mRes.mCOw[level];
             MatrixXd& O = mRes.mO[level];
             MatrixXd& S = mRes.mS[level];
             auto& phases = mRes.mPhases[level];
@@ -311,6 +330,17 @@ void Optimizer::optimize_positions(Hierarchy& mRes, int with_scale) {
                         weight_sum += weight;
                         if (weight_sum > RCPOVERFLOW) sum /= weight_sum;
                         sum -= n_i.dot(sum - v_i) * n_i;
+                    }
+
+                    if (COw.size() > 0) {
+                        float cw = COw[i];
+                        if (cw != 0) {
+                            Vector3d co = CO.col(i), cq = CQ.col(i);
+                            Vector3d d = co - sum;
+                            d -= cq.dot(d) * cq;
+                            sum += cw * d;
+                            sum -= n_i.dot(sum - v_i) * n_i;
+                        }
                     }
 
                     if (weight_sum > 0) {

--- a/src/optimizer.cpp
+++ b/src/optimizer.cpp
@@ -13,6 +13,8 @@
 #include "flow.hpp"
 #include "parametrizer.hpp"
 
+namespace qflow {
+
 #ifdef WITH_CUDA
 #    include <cuda_runtime.h>
 #endif
@@ -540,12 +542,12 @@ void Optimizer::optimize_positions_dynamic(
         }
         std::vector<double> b(O_compact.size() * 2);
         std::vector<double> x(O_compact.size() * 2);
-#ifdef WITH_OMP
-#pragma omp parallel for
-#endif
         std::vector<Vector3d> Q_compact(O_compact.size());
         std::vector<Vector3d> N_compact(O_compact.size());
         std::vector<Vector3d> V_compact(O_compact.size());
+#ifdef WITH_OMP
+#pragma omp parallel for
+#endif
         for (int i = 0; i < O_compact.size(); ++i) {
             Q_compact[i] = Q.col(Vind[i]);
             N_compact[i] = N.col(Vind[i]);
@@ -1373,3 +1375,5 @@ void Optimizer::optimize_positions_cuda(Hierarchy& mRes) {
 }
 
 #endif
+
+} // namespace qflow

--- a/src/optimizer.hpp
+++ b/src/optimizer.hpp
@@ -4,6 +4,8 @@
 #include "field-math.hpp"
 #include "hierarchy.hpp"
 
+namespace qflow {
+
 class Optimizer {
    public:
     Optimizer();
@@ -48,5 +50,7 @@ extern void PropagatePositionUpper(glm::dvec3* srcField, int num_position, glm::
                                    glm::dvec3* N, glm::dvec3* V, glm::dvec3* destField);
 
 #endif
+
+} // namespace qflow
 
 #endif

--- a/src/parametrizer-flip.cpp
+++ b/src/parametrizer-flip.cpp
@@ -6,6 +6,8 @@
 #include <unordered_map>
 #include <vector>
 
+namespace qflow {
+
 double Parametrizer::QuadEnergy(std::vector<int>& loop_vertices, std::vector<Vector4i>& res_quads,
                                 int level) {
     if (loop_vertices.size() < 4) return 0;
@@ -577,3 +579,5 @@ void Parametrizer::BuildTriangleManifold(DisajointTree& disajoint_tree, std::vec
                               nonManifold_compact);
      */
 }
+
+} // namespace qflow

--- a/src/parametrizer-int.cpp
+++ b/src/parametrizer-int.cpp
@@ -3,7 +3,11 @@
 #include <queue>
 #include <unordered_map>
 #include <vector>
+#include <random>
 #include "optimizer.hpp"
+
+namespace qflow {
+
 
 void Parametrizer::BuildEdgeInfo() {
     auto& F = hierarchy.mF;
@@ -51,6 +55,11 @@ void Parametrizer::BuildIntegerConstraints() {
     auto& Q = hierarchy.mQ[0];
     auto& N = hierarchy.mN[0];
     face_edgeOrients.resize(F.cols());
+
+    //Random number generator (for shuffling)
+    std::random_device rd;
+    std::mt19937 g(rd());
+    g.seed(hierarchy.rng_seed);
 
     // undirected edge to direct edge
     std::vector<std::pair<int, int>> E2D(edge_diff.size(), std::make_pair(-1, -1));
@@ -257,7 +266,7 @@ void Parametrizer::BuildIntegerConstraints() {
         // uniformly random manually modify variables so that the network has full flow.
         for (int i = 0; i < 2; ++i)
             for (auto& modified_var : modified_variables[i])
-                std::random_shuffle(modified_var.begin(), modified_var.end());
+                std::shuffle(modified_var.begin(), modified_var.end(), g);
 
         for (int j = 0; j < total_flows.size(); ++j) {
             for (int ii = 0; ii < 2; ++ii) {
@@ -397,7 +406,7 @@ void Parametrizer::BuildIntegerConstraints() {
     // uniformly random manually modify variables so that the network has full flow.
     for (int j = 0; j < 2; ++j) {
         for (auto& modified_var : modified_variables[j])
-            std::random_shuffle(modified_var.begin(), modified_var.end());
+            std::shuffle(modified_var.begin(), modified_var.end(), g);
     }
     for (int j = 0; j < total_flows.size(); ++j) {
         for (int ii = 0; ii < 2; ++ii) {
@@ -425,3 +434,5 @@ void Parametrizer::ComputeMaxFlow() {
     Optimizer::optimize_integer_constraints(hierarchy, singularities, flag_minimum_cost_flow);
     hierarchy.UpdateGraphValue(face_edgeOrients, face_edgeIds, edge_diff);
 }
+
+} // namespace qflow

--- a/src/parametrizer-mesh.cpp
+++ b/src/parametrizer-mesh.cpp
@@ -128,6 +128,20 @@ void Parametrizer::ComputeMeshStatus() {
 }
 
 void Parametrizer::ComputeSharpEdges() {
+    sharp_edges.resize(F.cols() * 3, 0);
+
+    if (flag_preserve_border) {
+        for (int i = 0; i < sharp_edges.size(); ++i) {
+            int re = E2E[i];
+            if (re == -1) {
+                sharp_edges[i] = 1;
+            }
+        }
+    }
+
+    if (flag_preserve_sharp == 0)
+        return;
+
     std::vector<Vector3d> face_normals(F.cols());
     for (int i = 0; i < F.cols(); ++i) {
         Vector3d p1 = V.col(F(0, i));
@@ -137,9 +151,6 @@ void Parametrizer::ComputeSharpEdges() {
     }
 
     double cos_thres = cos(60.0/180.0*3.141592654);
-    sharp_edges.resize(F.cols() * 3, 0);
-    if (flag_preserve_sharp == 0)
-        return;
     for (int i = 0; i < sharp_edges.size(); ++i) {
         int e = i;
         int re = E2E[e];

--- a/src/parametrizer-mesh.cpp
+++ b/src/parametrizer-mesh.cpp
@@ -8,13 +8,12 @@
 #include "dedge.hpp"
 #include <queue>
 
-void Parametrizer::Load(const char* filename) {
-    load(filename, V, F);
+namespace qflow {
+
+void Parametrizer::NormalizeMesh() {
     double maxV[3] = {-1e30, -1e30, -1e30};
     double minV[3] = {1e30, 1e30, 1e30};
-#ifdef WITH_OMP
-#pragma omp parallel for
-#endif
+
     for (int i = 0; i < V.cols(); ++i) {
         for (int j = 0; j < 3; ++j) {
             maxV[j] = std::max(maxV[j], V(j, i));
@@ -38,6 +37,11 @@ void Parametrizer::Load(const char* filename) {
     this->normalize_scale = scale;
     this->normalize_offset = Vector3d(0.5 * (maxV[0] + minV[0]), 0.5 * (maxV[1] + minV[1]), 0.5 * (maxV[2] + minV[2]));
     //    merge_close(V, F, 1e-6);
+}
+
+void Parametrizer::Load(const char* filename) {
+    load(filename, V, F);
+    NormalizeMesh();
 }
 
 void Parametrizer::Initialize(int faces) {
@@ -73,7 +77,6 @@ void Parametrizer::Initialize(int faces) {
         subdivide(F, V, rho, V2E, E2E, boundary, nonManifold, target_len);
     }
     
-    int t1 = GetCurrentTime64();
     while (!compute_direct_graph(V, F, V2E, E2E, boundary, nonManifold))
         ;
     generate_adjacency_matrix_uniform(F, V2E, E2E, nonManifold, adj);
@@ -105,8 +108,6 @@ void Parametrizer::Initialize(int faces) {
     hierarchy.mE2E = std::move(E2E);
     hierarchy.mF = std::move(F);
     hierarchy.Initialize(scale, flag_adaptive_scale);
-    int t2 = GetCurrentTime64();
-    printf("Initialize use time: %lf\n", (t2 - t1) * 1e-3);
 }
 
 void Parametrizer::ComputeMeshStatus() {
@@ -605,3 +606,5 @@ void Parametrizer::OutputMesh(const char* obj_name) {
     }
     os.close();
 }
+
+} // namespace qflow

--- a/src/parametrizer-scale.cpp
+++ b/src/parametrizer-scale.cpp
@@ -1,5 +1,7 @@
 #include "parametrizer.hpp"
 
+namespace qflow {
+
 void Parametrizer::ComputeInverseAffine()
 {
     if (flag_adaptive_scale == 0)
@@ -113,3 +115,5 @@ void Parametrizer::EstimateSlope() {
         }
     }
 }
+
+} // namespace qflow

--- a/src/parametrizer-sing.cpp
+++ b/src/parametrizer-sing.cpp
@@ -1,6 +1,9 @@
 #include "config.hpp"
 #include "field-math.hpp"
 #include "parametrizer.hpp"
+
+namespace qflow {
+
 void Parametrizer::ComputeOrientationSingularities() {
     MatrixXd &N = hierarchy.mN[0], &Q = hierarchy.mQ[0];
     const MatrixXi& F = hierarchy.mF;
@@ -135,3 +138,5 @@ void Parametrizer::AnalyzeValence() {
     printf("singularity: <%d %d> <%d %d>\n", (int)sing1.size(), (int)sing2.size(), count3, count4);
 }
 
+
+} // namespace qflow

--- a/src/parametrizer.cpp
+++ b/src/parametrizer.cpp
@@ -16,6 +16,8 @@
 #include <queue>
 #include <set>
 
+namespace qflow {
+
 void Parametrizer::ComputeIndexMap(int with_scale) {
     // build edge info
     auto& V = hierarchy.mV[0];
@@ -25,9 +27,9 @@ void Parametrizer::ComputeIndexMap(int with_scale) {
     auto& O = hierarchy.mO[0];
     auto& S = hierarchy.mS[0];
     // ComputeOrientationSingularities();
-    
+
     BuildEdgeInfo();
-    
+
     if (flag_preserve_sharp) {
         //        ComputeSharpO();
     }
@@ -101,7 +103,7 @@ void Parametrizer::ComputeIndexMap(int with_scale) {
                        edge_diff, edge_values, face_edgeOrients, face_edgeIds, sharp_edges,
                        singularities, 1);
     FixFlipSat();
-    
+
 #ifdef LOG_OUTPUT
     int t2 = GetCurrentTime64();
     printf("Flip use %lf\n", (t2 - t1) * 1e-3);
@@ -122,7 +124,7 @@ void Parametrizer::ComputeIndexMap(int with_scale) {
                                         sharp_constraints, flag_adaptive_scale);
 
     AdvancedExtractQuad();
-    
+
     FixValence();
 
     std::vector<int> sharp_o(O_compact.size(), 0);
@@ -242,3 +244,4 @@ void Parametrizer::ComputeIndexMap(int with_scale) {
     //                            hierarchy.mScale, false);
 }
 
+}  // namespace qflow

--- a/src/parametrizer.hpp
+++ b/src/parametrizer.hpp
@@ -166,6 +166,7 @@ class Parametrizer {
 
     // flag
     int flag_preserve_sharp = 0;
+    int flag_preserve_border = 0;
     int flag_adaptive_scale = 0;
     int flag_aggresive_sat = 0;
     int flag_minimum_cost_flow = 0;

--- a/src/parametrizer.hpp
+++ b/src/parametrizer.hpp
@@ -18,6 +18,9 @@
 #include "hierarchy.hpp"
 #include "post-solver.hpp"
 #include "serialize.hpp"
+
+namespace qflow {
+
 using namespace Eigen;
 
 typedef std::pair<unsigned int, unsigned int> Edge;
@@ -37,6 +40,7 @@ class Parametrizer {
     Parametrizer() {}
     // Mesh Initialization
     void Load(const char* filename);
+    void NormalizeMesh();
     void ComputeMeshStatus();
     void ComputeSmoothNormal();
     void ComputeSharpEdges();
@@ -170,5 +174,7 @@ class Parametrizer {
 extern void generate_adjacency_matrix_uniform(const MatrixXi& F, const VectorXi& V2E,
                                               const VectorXi& E2E, const VectorXi& nonManifold,
                                               AdjacentMatrix& adj);
+
+} // namespace qflow
 
 #endif

--- a/src/post-solver.cpp
+++ b/src/post-solver.cpp
@@ -16,6 +16,8 @@
 #include "post-solver.hpp"
 #include "serialize.hpp"
 
+namespace qflow {
+
 /// Coefficient of area constraint.  The magnitude is 1 if area is equal to 0.
 const double COEFF_AREA = 1;
 /// Coefficient of tangent constraint.  The magnitude is 0.03 if the bais is reference_length.
@@ -421,3 +423,5 @@ int main(int argc, char* argv[]) {
 }
 
 #endif
+
+} // namespace qflow

--- a/src/post-solver.hpp
+++ b/src/post-solver.hpp
@@ -12,6 +12,8 @@
 #include <vector>
 #include "disajoint-tree.hpp"
 
+namespace qflow {
+
 using namespace Eigen;
 
 /*
@@ -56,5 +58,7 @@ void optimize_quad_positions(std::vector<Vector3d>& O_quad, std::vector<Vector3d
                              MatrixXd& Q, MatrixXd& O, MatrixXi& F, VectorXi& V2E, VectorXi& E2E,
                              DisajointTree& disajoint_tree, double reference_length,
                              bool just_serialize = true);
+
+} // namespace qflow
 
 #endif /* post_solver_h */

--- a/src/serialize.hpp
+++ b/src/serialize.hpp
@@ -8,6 +8,8 @@
 #include <vector>
 #include "adjacent-matrix.hpp"
 
+namespace qflow {
+
 template <typename T, int A, int B>
 inline void Save(FILE* fp, const Eigen::Matrix<T, A, B>& m) {
     int r = m.rows(), c = m.cols();
@@ -119,5 +121,7 @@ void Read(FILE* fp, std::set<T>& p) {
     p.clear();
     for (auto& q : buffer) p.insert(q);
 }
+
+} // namespace qflow
 
 #endif

--- a/src/subdivide.cpp
+++ b/src/subdivide.cpp
@@ -8,6 +8,8 @@
 #include "field-math.hpp"
 #include "parametrizer.hpp"
 
+namespace qflow {
+
 void subdivide(MatrixXi &F, MatrixXd &V, VectorXd& rho, VectorXi &V2E, VectorXi &E2E, VectorXi &boundary,
                VectorXi &nonmanifold, double maxLength) {
     typedef std::pair<double, int> Edge;
@@ -510,3 +512,5 @@ void subdivide_edgeDiff(MatrixXi &F, MatrixXd &V, MatrixXd &N, MatrixXd &Q, Matr
         }
     }
 }
+
+} // namespace qflow

--- a/src/subdivide.hpp
+++ b/src/subdivide.hpp
@@ -1,7 +1,10 @@
 #include <Eigen/Core>
 #include <Eigen/Dense>
+
 #include "parametrizer.hpp"
 using namespace Eigen;
+
+namespace qflow {
 
 void subdivide(MatrixXi &F, MatrixXd &V, VectorXd& rho, VectorXi &V2E, VectorXi &E2E, VectorXi &boundary,
                VectorXi &nonmanifold, double maxLength);
@@ -11,3 +14,4 @@ void subdivide_edgeDiff(MatrixXi &F, MatrixXd &V, MatrixXd &N, MatrixXd &Q, Matr
                     std::vector<Vector2i> &edge_diff, std::vector<DEdge> &edge_values,
                     std::vector<Vector3i> &face_edgeOrients, std::vector<Vector3i> &face_edgeIds,
                     std::vector<int>& sharp_edges, std::map<int, int> &singularities, int max_len);
+} // namespace qflow


### PR DESCRIPTION
I've ported over the border edge preservation from Instant Meshes:

| Input mesh            | Old output (without border preservation) | New output |
| :---:         |     :---:      |          :---: |
|   ![1](https://user-images.githubusercontent.com/312503/64015466-e69fbc00-cb24-11e9-8f66-f5132e47ac05.png) | ![2](https://user-images.githubusercontent.com/312503/64015519-fd461300-cb24-11e9-9186-80b87d473516.png)  | ![3](https://user-images.githubusercontent.com/312503/64015595-28c8fd80-cb25-11e9-999a-5fa274c7ca71.png)  |

However, there are still a few issues that I would need some input on. The mesh now still meshes holes if the resolution is too small:

| Input mesh            |  Output low res | Output high res |
| :---:         |     :---:      |          :---: |
| ![4](https://user-images.githubusercontent.com/312503/64021543-81ec5d80-cb34-11e9-8e63-8fe11dbc3c1a.png) | ![5](https://user-images.githubusercontent.com/312503/64021558-8c0e5c00-cb34-11e9-8663-bd3f841c6fbf.png) | ![6](https://user-images.githubusercontent.com/312503/64021584-97618780-cb34-11e9-88ed-8799a04f3a40.png) |

In addition, I'm not sure how I should make the scaling work in the `propagate_constraints` function (marked as `FIXME`).

Any help in this matter would be greatly appreciated.

Note that this is built on top of my other pull request so only the most recent commit is relevant for this specific pull request.