### PR TITLE
Fix boundary naming (border -> boundary)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,8 +30,8 @@ int main(int argc, char** argv) {
             output_obj = argv[i + 1];
         } else if (strcmp(argv[i], "-sharp") == 0) {
             field.flag_preserve_sharp = 1;
-        } else if (strcmp(argv[i], "-border") == 0) {
-            field.flag_preserve_border = 1;
+        } else if (strcmp(argv[i], "-boundary") == 0) {
+            field.flag_preserve_boundary = 1;
         } else if (strcmp(argv[i], "-adaptive") == 0) {
             field.flag_adaptive_scale = 1;
         } else if (strcmp(argv[i], "-mcf") == 0) {
@@ -56,8 +56,8 @@ int main(int argc, char** argv) {
     t2 = GetCurrentTime64();
     printf("Use %lf seconds\n", (t2 - t1) * 1e-3);
 
-    if (field.flag_preserve_border) {
-        printf("Add border constrains...\n");
+    if (field.flag_preserve_boundary) {
+        printf("Add boundary constrains...\n");
         Hierarchy& mRes = field.hierarchy;
         mRes.clearConstraints();
         for (uint32_t i = 0; i < 3 * mRes.mF.cols(); ++i) {

--- a/src/parametrizer-mesh.cpp
+++ b/src/parametrizer-mesh.cpp
@@ -124,7 +124,7 @@ void Parametrizer::ComputeMeshStatus() {
 void Parametrizer::ComputeSharpEdges() {
     sharp_edges.resize(F.cols() * 3, 0);
 
-    if (flag_preserve_border) {
+    if (flag_preserve_boundary) {
         for (int i = 0; i < sharp_edges.size(); ++i) {
             int re = E2E[i];
             if (re == -1) {

--- a/src/parametrizer.hpp
+++ b/src/parametrizer.hpp
@@ -162,7 +162,7 @@ class Parametrizer {
 
     // flag
     int flag_preserve_sharp = 0;
-    int flag_preserve_border = 0;
+    int flag_preserve_boundary = 0;
     int flag_adaptive_scale = 0;
     int flag_aggresive_sat = 0;
     int flag_minimum_cost_flow = 0;


### PR DESCRIPTION
I managed to somehow use the incorrect terminology when coding the previous boundary constraints patch. I've corrected the usage of `border` instead of the intended `boundary`.